### PR TITLE
Refactor/modal: 모달 추상화 및 관심사 분리

### DIFF
--- a/client/src/components/atoms/modal/Header.tsx
+++ b/client/src/components/atoms/modal/Header.tsx
@@ -1,0 +1,35 @@
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import * as Style from './HeaderStyle';
+import TooltipButton from '../button/tooltipButton/TooltipButton';
+import { faXmark } from '@fortawesome/free-solid-svg-icons';
+import { IconProp } from '@fortawesome/fontawesome-svg-core';
+import { Tooltip } from '../../../types/ModalTypes';
+
+interface ModalHeader {
+  children?: React.ReactNode;
+  title: string;
+  tooltip: Tooltip;
+  icon: IconProp;
+  closeModal: React.MouseEventHandler<HTMLDivElement>;
+}
+
+const Header = (props: ModalHeader) => {
+  const { title, tooltip, icon, closeModal } = props;
+
+  return (
+    <>
+      <Style.Header>
+        <Style.Title>
+          {title}
+          <FontAwesomeIcon icon={icon} />
+          <TooltipButton info={tooltip?.info} place={tooltip?.place} />
+        </Style.Title>
+        <Style.Button onClick={closeModal}>
+          <FontAwesomeIcon icon={faXmark} size="lg" />
+        </Style.Button>
+      </Style.Header>
+    </>
+  );
+};
+
+export default Header;

--- a/client/src/components/atoms/modal/HeaderStyle.ts
+++ b/client/src/components/atoms/modal/HeaderStyle.ts
@@ -1,0 +1,30 @@
+import styled from 'styled-components';
+export const Header = styled.div`
+  display: flex;
+  justify-content: space-between;
+  width: 95%;
+  height: 50px;
+  border-bottom: 1px solid rgb(51, 52, 53);
+`;
+export const Title = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  color: rgb(51, 52, 53);
+  line-height: 40px;
+  font-size: 24px;
+  font-weight: 600;
+  margin: 8px 0 0 8px;
+  > svg {
+    margin-left: 16px;
+    font-size: 20px;
+  }
+`;
+export const Button = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: transparent;
+  padding: 8px 8px 0;
+  cursor: pointer;
+`;

--- a/client/src/components/atoms/modal/ModalItem.tsx
+++ b/client/src/components/atoms/modal/ModalItem.tsx
@@ -1,0 +1,32 @@
+import { useDispatch } from 'react-redux';
+import { closeModal } from '../../../redux/modalSlice';
+import * as Style from './ModalStyle';
+import Header from './Header';
+import { modalList } from '../../../router/Modals';
+
+interface ModalType {
+  modalType: string;
+  children: React.ReactNode;
+}
+const ModalItem: React.FC<ModalType> = ({ modalType, children }) => {
+  const type = modalList.find(modal => {
+    return modal.type === modalType;
+  });
+  const dispatch = useDispatch();
+  const handleCloseModal = () => {
+    dispatch(closeModal());
+  };
+  return (
+    <Style.Basic>
+      <Header
+        closeModal={handleCloseModal}
+        title={type?.label}
+        tooltip={type?.tooltip}
+        icon={type?.iconProp}
+      />
+      <Style.Content>{children}</Style.Content>
+    </Style.Basic>
+  );
+};
+
+export default ModalItem;

--- a/client/src/components/atoms/modal/ModalStyle.ts
+++ b/client/src/components/atoms/modal/ModalStyle.ts
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-export const Blueprint = styled.div`
+export const Basic = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -11,6 +11,8 @@ export const Blueprint = styled.div`
   transition: all 0.5s cubic-bezier(0.55, 0.085, 0.68, 0.53) both;
   animation: slideIn 0.5s;
   width: 100%;
+  height: 500px;
+  position: relative;
 
   @keyframes slideIn {
     0% {
@@ -22,25 +24,6 @@ export const Blueprint = styled.div`
       opacity: 1;
     }
   }
-`;
-
-export const Todo = styled(Blueprint)`
-  height: 500px;
-`;
-
-export const Basic = styled(Blueprint)`
-  height: 500px;
-  position: relative;
-`;
-
-export const Store = styled(Blueprint)`
-  width: 100%;
-  height: 500px;
-`;
-
-export const Calendar = styled(Blueprint)`
-  width: 100%;
-  height: 600px;
 `;
 
 export const Header = styled.div`
@@ -82,13 +65,7 @@ export const Info = styled(Button)`
   cursor: pointer;
 `;
 
-export const RealButton = styled.button`
-  background-color: transparent;
-  border: none;
-  margin-left: 4px;
-`;
-
-export const Utility = styled.div`
+export const Content = styled.div`
   height: 100%;
   width: 100%;
 `;

--- a/client/src/components/module/letter/Letters.tsx
+++ b/client/src/components/module/letter/Letters.tsx
@@ -9,7 +9,7 @@ import { RightBottomLayout } from '../../atoms/layout/Layouts';
 import Pagination from '../../atoms/pagination/Pagination';
 import Overlay from '../../atoms/overlay/Overlay';
 import LetterItem from './item/LetterItem';
-import { MailModal } from '../modal/Modal';
+import BasicModal from '../../atoms/modal/ModalItem';
 import { toast } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 import * as Style from './Style';
@@ -47,7 +47,7 @@ const Letters = ({ setIsOpen, isOpen }: ModalType) => {
   return (
     <>
       {popup && <Overlay />}
-      <MailModal>
+      <BasicModal modalType="LetterModal">
         <Style.ContentWrap>
           {letters ? (
             letters?.data
@@ -79,7 +79,7 @@ const Letters = ({ setIsOpen, isOpen }: ModalType) => {
             setPage={setPage}
           />
         </footer>
-      </MailModal>
+      </BasicModal>
     </>
   );
 };

--- a/client/src/components/module/modal/Modal.js
+++ b/client/src/components/module/modal/Modal.js
@@ -3,17 +3,12 @@ import {
   faXmark,
   faHighlighter,
   faStore,
-  faUserGroup,
   faFilm,
 } from '@fortawesome/free-solid-svg-icons';
-import {
-  faEnvelope,
-  faCircleQuestion,
-} from '@fortawesome/free-regular-svg-icons';
+import { faCircleQuestion } from '@fortawesome/free-regular-svg-icons';
 import ReactTooltip from 'react-tooltip';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import { closeModal } from '../../../redux/modalSlice';
-import TooltipButton from '../../atoms/button/tooltipButton/TooltipButton';
 import * as Style from './Style';
 
 const TodoModal = ({ children, lookBack }) => {
@@ -43,31 +38,6 @@ const TodoModal = ({ children, lookBack }) => {
   );
 };
 
-const MailModal = ({ children }) => {
-  const dispatch = useDispatch();
-  const handleCloseModal = () => {
-    dispatch(closeModal());
-  };
-  return (
-    <Style.Mail>
-      <Style.Header>
-        <Style.Title>
-          편지함
-          <FontAwesomeIcon icon={faEnvelope} />
-          <TooltipButton
-            info="오른쪽 아래 + 버튼을 눌러서 친구에게 편지를 보낼 수 있어요."
-            place="right"
-          />
-        </Style.Title>
-        <Style.Button onClick={handleCloseModal}>
-          <FontAwesomeIcon icon={faXmark} size="lg" />
-        </Style.Button>
-      </Style.Header>
-      <Style.Utility>{children}</Style.Utility>
-    </Style.Mail>
-  );
-};
-
 const StoreModal = ({ children }) => {
   const dispatch = useDispatch();
   const handleCloseModal = () => {
@@ -89,36 +59,10 @@ const StoreModal = ({ children }) => {
   );
 };
 
-const FriendModal = ({ children }) => {
+const LookBackModal = ({ children }) => {
   const dispatch = useDispatch();
   const handleCloseModal = () => {
     dispatch(closeModal());
-  };
-  return (
-    <Style.Mail>
-      <Style.Header>
-        <Style.Title>
-          친구
-          <FontAwesomeIcon icon={faUserGroup} />
-          <TooltipButton
-            info="+ 버튼을 눌러서 친구의 무드카드를 얻어보세요."
-            place="right"
-          />
-        </Style.Title>
-        <Style.Button onClick={handleCloseModal}>
-          <FontAwesomeIcon icon={faXmark} size="lg" />
-        </Style.Button>
-      </Style.Header>
-      <Style.Utility>{children}</Style.Utility>
-    </Style.Mail>
-  );
-};
-
-const LookBackModal = ({ children, setHiddenCard }) => {
-  const dispatch = useDispatch();
-  const handleCloseModal = () => {
-    dispatch(closeModal());
-    setHiddenCard(false);
   };
   return (
     <Style.Calendar>
@@ -140,4 +84,4 @@ const LookBackModal = ({ children, setHiddenCard }) => {
   );
 };
 
-export { TodoModal, MailModal, StoreModal, FriendModal, LookBackModal };
+export { TodoModal, StoreModal, LookBackModal };

--- a/client/src/components/templates/modals/GlobalModal.tsx
+++ b/client/src/components/templates/modals/GlobalModal.tsx
@@ -1,65 +1,22 @@
 import { useSelector } from 'react-redux';
 import { selectModal } from '../../../redux/modalSlice';
-import FriendModal from './friend/Friend';
-import LetterModal from './letter/Letter';
-import TodoModal from './todo/TodoList';
-import ThemeModal from './theme/ThemeStore';
-import MonthlyLookback from './monthly/MonthlyLookback';
-import YearlyLookBack from './yearly/YearlyLookBack';
-import { GlobalModalType } from '../../../types/ModalTypes';
+import { modalList } from '../../../router/Modals';
+import IsFullModal from './IsFullModal';
 
-const MODAL_TYPES = {
-  LetterModal: 'LetterModal',
-  TodoModal: 'TodoModal',
-  FriendModal: 'FriendModal',
-  ThemeModal: 'ThemeModal',
-  MonthlyModal: 'MonthlyModal',
-  LookbackModal: 'LookbackModal',
-};
-
-function GlobalModal({ setHiddenCard }: GlobalModalType) {
-  const MODAL_COMPONENTS = [
-    {
-      type: MODAL_TYPES.LetterModal,
-      component: <LetterModal />,
-    },
-    {
-      type: MODAL_TYPES.TodoModal,
-      component: <TodoModal lookbackRefresher={undefined} />,
-    },
-    {
-      type: MODAL_TYPES.FriendModal,
-      component: <FriendModal />,
-    },
-    {
-      type: MODAL_TYPES.ThemeModal,
-      component: <ThemeModal />,
-    },
-    {
-      type: MODAL_TYPES.MonthlyModal,
-      component: <MonthlyLookback setHiddenCard={setHiddenCard} />,
-    },
-    {
-      type: MODAL_TYPES.LookbackModal,
-      component: (
-        <YearlyLookBack
-          setHiddenCard={setHiddenCard}
-          lookbackRefresh={undefined}
-        />
-      ),
-    },
-  ];
+function GlobalModal() {
   const { modalType, isOpen } = useSelector(selectModal);
-  if (!isOpen) return;
+  if (!isOpen) {
+    return <IsFullModal isFull={false}>{null}</IsFullModal>;
+  }
 
-  const findModal = MODAL_COMPONENTS.find(modal => {
+  const findModal = modalList.find(modal => {
     return modal.type === modalType;
   });
 
   const renderModal = () => {
     return findModal.component;
   };
-  return <div style={{ display: 'flex', width: '100%' }}>{renderModal()}</div>;
+  return <IsFullModal isFull={findModal.isFull}>{renderModal()}</IsFullModal>;
 }
 
 export default GlobalModal;

--- a/client/src/components/templates/modals/IsFullModal.tsx
+++ b/client/src/components/templates/modals/IsFullModal.tsx
@@ -1,0 +1,25 @@
+import { ContentLayout } from '../../atoms/layout/Layouts';
+import MoodSelector from '../../module/mood/MoodSelector';
+
+interface FullPageProp {
+  isFull: boolean;
+  children: React.ReactNode;
+}
+
+const IsFullModal: React.FC<FullPageProp> = ({ isFull, children }) => {
+  return (
+    <ContentLayout>
+      {isFull ? null : (
+        <div>
+          <MoodSelector
+            lookbackRefresher={undefined}
+            pointRefresher={undefined}
+          />
+        </div>
+      )}
+      <div style={{ display: 'flex', width: '100%' }}>{children}</div>
+    </ContentLayout>
+  );
+};
+
+export default IsFullModal;

--- a/client/src/components/templates/modals/friend/Friend.tsx
+++ b/client/src/components/templates/modals/friend/Friend.tsx
@@ -8,7 +8,7 @@ import { RightBottomLayout } from '../../../atoms/layout/Layouts';
 import Button from '../../../atoms/button/commonButton/Button';
 import Overlay from '../../../atoms/overlay/Overlay';
 import Pagination from '../../../atoms/pagination/Pagination';
-import { FriendModal } from '../../../module/modal/Modal';
+import BasicModal from '../../../atoms/modal/ModalItem';
 import AddFriend from '../../../module/friend/create/AddFriend';
 import FriendCard from '../../../module/friend/card/FriendCard';
 import { toast } from 'react-toastify';
@@ -16,7 +16,6 @@ import 'react-toastify/dist/ReactToastify.css';
 import * as Style from './Style';
 import { useQuery } from '@tanstack/react-query';
 import { Friend } from '../../../module/friend/FriendType';
-import { PaletteCode } from '../../../../types/UserType';
 
 const Friends = () => {
   const [isOpen, setIsOpen] = useState(false);
@@ -81,7 +80,7 @@ const Friends = () => {
   return (
     <>
       {popup && <Overlay />}
-      <FriendModal>
+      <BasicModal modalType="FriendModal">
         <Style.CardLayout>
           {friends
             ? friends.data
@@ -115,7 +114,7 @@ const Friends = () => {
             setPage={setPage}
           />
         </footer>
-      </FriendModal>
+      </BasicModal>
       {isOpen ? (
         <>
           <AddFriend setIsOpen={setIsOpen} friends={friends.data} />

--- a/client/src/components/templates/pages/home/Home.js
+++ b/client/src/components/templates/pages/home/Home.js
@@ -3,12 +3,10 @@ import { useSelector } from 'react-redux';
 import axios from 'axios';
 import { ContentLayout } from '../../../atoms/layout/Layouts';
 import Header from '../../../module/header/Header';
-import MoodSelector from '../../../module/mood/MoodSelector';
 import GlobalModal from '../../modals/GlobalModal';
 import Mobile from '../mobileAlert/MobileAlert';
 import { getPoint } from '../../../../api/GetPointApi';
 import { memberIdSelector } from '../../../../redux/hooks';
-import { selectModal } from '../../../../redux/modalSlice';
 import { getCookie } from '../../../../utils/cookie';
 import * as Style from './Style';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
@@ -16,17 +14,7 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 const Home = () => {
   const [mobile, setMobile] = useState();
   const memberId = useSelector(memberIdSelector);
-  const { modalType } = useSelector(selectModal);
-  const [hiddenCard, setHiddenCard] = useState(false);
   const accessToken = getCookie('accessToken');
-
-  useEffect(() => {
-    if (modalType === 'LookbackModal' || modalType === 'MonthlyModal') {
-      setHiddenCard(true);
-    } else {
-      setHiddenCard(false);
-    }
-  }, [modalType]);
 
   const queryClient = useQueryClient();
   const point = useQuery({
@@ -60,6 +48,7 @@ const Home = () => {
       window.removeEventListener('resize', handleResize);
     };
   }, []);
+
   return (
     <Style.Browser>
       <Header point={point?.data} />
@@ -68,14 +57,7 @@ const Home = () => {
           <Mobile />
         </ContentLayout>
       ) : (
-        <ContentLayout>
-          {hiddenCard ? null : (
-            <div>
-              <MoodSelector />
-            </div>
-          )}
-          <GlobalModal setHiddenCard={setHiddenCard} />
-        </ContentLayout>
+        <GlobalModal />
       )}
     </Style.Browser>
   );

--- a/client/src/router/Modals.tsx
+++ b/client/src/router/Modals.tsx
@@ -14,15 +14,17 @@ import {
   faUserGroup,
 } from '@fortawesome/free-solid-svg-icons';
 import { IconProp } from '@fortawesome/fontawesome-svg-core';
+import { Tooltip } from '../types/ModalTypes';
 
 interface Modal {
   type: string;
   component: JSX.Element;
   label: string;
-  ModalIcon: typeof FontAwesomeIcon;
+  modalIcon: typeof FontAwesomeIcon;
   iconProp?: IconProp;
   isFull: boolean;
   withAuth: boolean;
+  tooltip?: Tooltip;
 }
 
 export const modalList: Modal[] = [
@@ -30,16 +32,20 @@ export const modalList: Modal[] = [
     type: 'LetterModal',
     component: <Letter />,
     label: '편지',
-    ModalIcon: FontAwesomeIcon,
+    modalIcon: FontAwesomeIcon,
     iconProp: faEnvelope,
     isFull: false,
     withAuth: false,
+    tooltip: {
+      info: '오른쪽 아래 + 버튼을 눌러서 친구에게 편지를 보낼 수 있어요.',
+      place: 'right',
+    },
   },
   {
     type: 'TodoModal',
     component: <TodoList lookbackRefresher={undefined} />,
     label: '오늘할일',
-    ModalIcon: FontAwesomeIcon,
+    modalIcon: FontAwesomeIcon,
     iconProp: faHighlighter,
     isFull: false,
     withAuth: false,
@@ -48,16 +54,20 @@ export const modalList: Modal[] = [
     type: 'FriendModal',
     component: <Friends />,
     label: '친구',
-    ModalIcon: FontAwesomeIcon,
+    modalIcon: FontAwesomeIcon,
     iconProp: faUserGroup,
     isFull: false,
     withAuth: false,
+    tooltip: {
+      info: '+ 버튼을 눌러서 친구의 무드카드를 얻어보세요.',
+      place: 'right',
+    },
   },
   {
     type: 'ThemeModal',
     component: <ThemeStore />,
     label: '색상테마',
-    ModalIcon: FontAwesomeIcon,
+    modalIcon: FontAwesomeIcon,
     iconProp: faStore,
     isFull: false,
     withAuth: false,
@@ -66,7 +76,7 @@ export const modalList: Modal[] = [
     type: 'MonthlyModal',
     component: <MonthlyLookback setHiddenCard={undefined} />,
     label: '한달기록',
-    ModalIcon: FontAwesomeIcon,
+    modalIcon: FontAwesomeIcon,
     iconProp: faCalendarDays,
     isFull: true,
     withAuth: true,
@@ -77,7 +87,7 @@ export const modalList: Modal[] = [
       <LookBack lookbackRefresh={undefined} setHiddenCard={undefined} />
     ),
     label: '일년기록',
-    ModalIcon: FontAwesomeIcon,
+    modalIcon: FontAwesomeIcon,
     iconProp: faFilm,
     isFull: true,
     withAuth: true,

--- a/client/src/router/Modals.tsx
+++ b/client/src/router/Modals.tsx
@@ -1,0 +1,85 @@
+import Letter from '../components/templates/modals/letter/Letter';
+import TodoList from '../components/templates/modals/todo/TodoList';
+import Friends from '../components/templates/modals/friend/Friend';
+import ThemeStore from '../components/templates/modals/theme/ThemeStore';
+import MonthlyLookback from '../components/templates/modals/monthly/MonthlyLookback';
+import LookBack from '../components/templates/modals/yearly/YearlyLookBack';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import {
+  faCalendarDays,
+  faEnvelope,
+  faFilm,
+  faHighlighter,
+  faStore,
+  faUserGroup,
+} from '@fortawesome/free-solid-svg-icons';
+import { IconProp } from '@fortawesome/fontawesome-svg-core';
+
+interface Modal {
+  type: string;
+  component: JSX.Element;
+  label: string;
+  ModalIcon: typeof FontAwesomeIcon;
+  iconProp?: IconProp;
+  isFull: boolean;
+  withAuth: boolean;
+}
+
+export const modalList: Modal[] = [
+  {
+    type: 'LetterModal',
+    component: <Letter />,
+    label: '편지',
+    ModalIcon: FontAwesomeIcon,
+    iconProp: faEnvelope,
+    isFull: false,
+    withAuth: false,
+  },
+  {
+    type: 'TodoModal',
+    component: <TodoList lookbackRefresher={undefined} />,
+    label: '오늘할일',
+    ModalIcon: FontAwesomeIcon,
+    iconProp: faHighlighter,
+    isFull: false,
+    withAuth: false,
+  },
+  {
+    type: 'FriendModal',
+    component: <Friends />,
+    label: '친구',
+    ModalIcon: FontAwesomeIcon,
+    iconProp: faUserGroup,
+    isFull: false,
+    withAuth: false,
+  },
+  {
+    type: 'ThemeModal',
+    component: <ThemeStore />,
+    label: '색상테마',
+    ModalIcon: FontAwesomeIcon,
+    iconProp: faStore,
+    isFull: false,
+    withAuth: false,
+  },
+  {
+    type: 'MonthlyModal',
+    component: <MonthlyLookback setHiddenCard={undefined} />,
+    label: '한달기록',
+    ModalIcon: FontAwesomeIcon,
+    iconProp: faCalendarDays,
+    isFull: true,
+    withAuth: true,
+  },
+  {
+    type: 'LookbackModal',
+    component: (
+      <LookBack lookbackRefresh={undefined} setHiddenCard={undefined} />
+    ),
+    label: '일년기록',
+    ModalIcon: FontAwesomeIcon,
+    iconProp: faFilm,
+    isFull: true,
+    withAuth: true,
+  },
+];

--- a/client/src/types/ModalTypes.ts
+++ b/client/src/types/ModalTypes.ts
@@ -1,3 +1,5 @@
+import { Place, TooltipProps } from 'react-tooltip';
+
 export interface ModalType {
   setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
   isOpen: boolean;
@@ -12,4 +14,9 @@ export type Modal =
 
 export interface GlobalModalType {
   setHiddenCard: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+export interface Tooltip extends TooltipProps {
+  info: string;
+  place?: Place;
 }


### PR DESCRIPTION
### Changes 📝
하드코딩되어있던 모달 컴포넌트를 추상화해서 atom의 부품으로서 재사용할 수 있도록 했습니다. 
그 과정에서 관심사를 분리했어요.
모달에 `position: relative;` 가 있어서 혹여나 다른 분들 ui가 무너질까봐 일단 friend, letter 모달만 교체를 해주었습니다.
확인 한번 해보시고 적용해보면 좋을 것 같아요.
문제가 있다면 style을 props로 받는 방법을 쓸 수도 있을 것 같습니다.
의견 있다면 언제든 말씀해주세요!
<br>

### Test Checklist ☑️
- [ ] modal list 분리해 router 폴더에 둠
- [ ] home에서 화면을 차지하는 모달 너비에 따라 무드카드 on/off하는 로직 분리해 isFullModal 파일 작성, templates/modal 에 위치하도록 함
- [ ] module에 있는 모달 atom으로 header/modalItem으로 나누어 추상화함. atoms/modal에 위치
