### PR TITLE
refactor: auth 필요성에 따라 login popup / logout 띄우기

### DIFF
--- a/client/src/components/atoms/gnb/GnbItem.tsx
+++ b/client/src/components/atoms/gnb/GnbItem.tsx
@@ -1,6 +1,8 @@
 import { IconProp } from '@fortawesome/fontawesome-svg-core';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { DarkIcon, Label, NavItem } from './style';
+import usePopUp from '../../../utils/usePopUp';
+import React from 'react';
 
 interface GnbItemProps {
   label: string;
@@ -9,13 +11,17 @@ interface GnbItemProps {
 }
 
 const GnbItem = (props: GnbItemProps) => {
+  const { label, icon, onClick } = props;
+
   return (
-    <NavItem onClick={props.onClick}>
-      <DarkIcon>
-        <FontAwesomeIcon icon={props.icon} size="lg" />
-      </DarkIcon>
-      <Label>{props.label}</Label>
-    </NavItem>
+    <>
+      <NavItem onClick={onClick}>
+        <DarkIcon>
+          <FontAwesomeIcon icon={icon} size="lg" />
+        </DarkIcon>
+        <Label>{label}</Label>
+      </NavItem>
+    </>
   );
 };
 

--- a/client/src/components/module/header/gnb/Gnb.tsx
+++ b/client/src/components/module/header/gnb/Gnb.tsx
@@ -4,36 +4,49 @@ import GnbItem from '../../../atoms/gnb/GnbItem';
 import { openModal } from '../../../../redux/modalSlice';
 import { Bubble } from './style';
 import LogoutItem from '../../../atoms/gnb/LogoutItem';
+import { getCookie } from '../../../../utils/cookie';
+import Overlay from '../../../atoms/overlay/Overlay';
+import usePopUp from '../../../../utils/usePopUp';
 
 interface GnbDispatchType {
   type: string;
+  withAuth: boolean;
 }
 
 const Gnb = () => {
+  const accessToken = getCookie('accessToken');
+
   const dispatch = useDispatch();
+  const { authPopup, handlePopup } = usePopUp();
   const handleModal = (modal: GnbDispatchType) => {
-    dispatch(
-      openModal({
-        modalType: modal.type,
-        isOpen: true,
-      })
-    );
+    modal.withAuth && !accessToken
+      ? handlePopup(modal.withAuth)
+      : dispatch(
+          openModal({
+            modalType: modal.type,
+            isOpen: true,
+          })
+        );
   };
 
+  //withAuth & !accessToken일때 popup
   return (
-    <Bubble>
-      {modalList.map(modal => {
-        return (
-          <GnbItem
-            key={modal.type}
-            label={modal.label}
-            icon={modal.iconProp}
-            onClick={() => handleModal(modal)}
-          />
-        );
-      })}
-      <LogoutItem />
-    </Bubble>
+    <>
+      {authPopup && <Overlay />}
+      <Bubble>
+        {modalList.map(modal => {
+          return (
+            <GnbItem
+              key={modal.type}
+              label={modal.label}
+              icon={modal.iconProp}
+              onClick={() => handleModal(modal)}
+            />
+          );
+        })}
+        {accessToken ? <LogoutItem /> : null}
+      </Bubble>
+    </>
   );
 };
 

--- a/client/src/utils/usePopUp.ts
+++ b/client/src/utils/usePopUp.ts
@@ -1,0 +1,22 @@
+import { useState } from 'react';
+import { toast } from 'react-toastify';
+import { getCookie } from './cookie';
+
+const usePopUp = () => {
+  const [authPopup, setPopup] = useState(false);
+  const accessToken = getCookie('accessToken');
+
+  const handlePopup = (withAuth: boolean) => {
+    if (withAuth && !accessToken) {
+      setPopup(true);
+      toast('먼저 로그인해주세요', {
+        className: 'toast-login',
+        onClose: () => setPopup(false),
+      });
+    }
+  };
+
+  return { authPopup, handlePopup };
+};
+
+export default usePopUp;


### PR DESCRIPTION
### Changes 📝
#203 
modal의 withAuth에 따라 login 유도 팝업을 띄우거나, gnb에 logout 버튼 띄움
<br>

### Test Checklist ☑️
- [ ] 한달기록, 일년기록은 로그인해야 접근 가능, 오버레이와 함께 팝업 문구가 나타남
- [ ] 로그인하지 않았을 때 logout 버튼이 메뉴에서 보이지 않도록 함.
