### PR TITLE
Hotfix/header: 유저네임 영역 오늘 무드 받아오는 로직 수정

### DIFF
--- a/client/src/api/FriendDataApi.js
+++ b/client/src/api/FriendDataApi.js
@@ -8,18 +8,6 @@ export const getFriends = async memberId => {
   return res.data;
 };
 
-export const getAllPalette = async () => {
-  const res = await axios.get(serverUrl + '/palette');
-  // const res = await axios.get(mockUrl + '/palette');
-  return res.data;
-};
-
-export const getSpecificPalette = async paletteCode => {
-  const res = await axios.get(serverUrl + `/palette/${paletteCode}`);
-  // const res = await axios.get(mockUrl + `/palette?paletteCode=${paletteCode}`);
-  return res.data;
-};
-
 export const getAllMembers = async () => {
   const res = await axios.get(serverUrl + '/members');
   // const res = await axios.get(mockUrl + '/members');

--- a/client/src/api/MoodApi.ts
+++ b/client/src/api/MoodApi.ts
@@ -1,0 +1,9 @@
+import axios from 'axios';
+const serverUrl = process.env.REACT_APP_BASIC_URL;
+const mockUrl = 'http://localhost:3001';
+
+export const getDayMood = async (displayName: string) => {
+  const res = await axios.get(serverUrl + `/mood/day/${displayName}`);
+  // const res = await axios.get(mockUrl + `/moods?moodId=1`);
+  return res.data;
+};

--- a/client/src/api/PaletteApi.ts
+++ b/client/src/api/PaletteApi.ts
@@ -1,0 +1,15 @@
+import axios from 'axios';
+const serverUrl = process.env.REACT_APP_BASIC_URL;
+const mockUrl = 'http://localhost:3001';
+
+export const getAllPalette = async () => {
+  const res = await axios.get(serverUrl + '/palette');
+  // const res = await axios.get(mockUrl + '/palette');
+  return res.data;
+};
+
+export const getSpecificPalette = async paletteCode => {
+  const res = await axios.get(serverUrl + `/palette/${paletteCode}`);
+  // const res = await axios.get(mockUrl + `/palette?paletteCode=${paletteCode}`);
+  return res.data;
+};

--- a/client/src/components/module/header/user/User.tsx
+++ b/client/src/components/module/header/user/User.tsx
@@ -4,20 +4,27 @@ import * as Style from '../HeaderStyle';
 import { memberIdSelector } from '../../../../redux/hooks';
 import GoogleLogin from '../login/GoogleLogin';
 import Username from '../../../atoms/username/Username';
-import { moodSelector, paletteCodeSelector } from '../../../../redux/hooks';
 import PointDisplay from './PointDisplay';
 import { useQuery } from '@tanstack/react-query';
 import { getUserInfo } from '../../../../api/UserInfoAPI';
+import { getDayMood } from '../../../../api/MoodApi';
 
 const User = ({ onClick }) => {
   const accessToken = getCookie('accessToken');
-  const userMood = useSelector(moodSelector);
-  const userPalette = useSelector(paletteCodeSelector);
   // userInfo
   const memberId = useSelector(memberIdSelector);
   const { data, isLoading, isError } = useQuery(['userInfo', memberId], {
     queryFn: async () => {
       const data = await getUserInfo(memberId);
+      return data;
+    },
+  });
+  const userInfo = data;
+  // todayMood
+  const dayMood = useQuery({
+    queryKey: ['dayMood'],
+    queryFn: async () => {
+      const data = await getDayMood(userInfo?.displayName);
       return data;
     },
   });
@@ -28,21 +35,15 @@ const User = ({ onClick }) => {
   if (isError) {
     return <div>error</div>;
   }
-  const userInfo = data;
-
-  const userMoodColor = userPalette?.data?.find(color => {
-    if (userMood) {
-      return userMood.mood === color.mood;
-    } else {
-      return 'inherit';
-    }
-  });
 
   return (
     <>
       {accessToken ? (
         <>
-          <Username onClick={onClick} color={userMoodColor?.colorCode}>
+          <Username
+            onClick={onClick}
+            color={dayMood?.data?.moodPaletteDetails?.colorCode}
+          >
             {userInfo?.displayName}
           </Username>
           <PointDisplay point={userInfo?.point} />

--- a/client/src/components/templates/modals/friend/Friend.tsx
+++ b/client/src/components/templates/modals/friend/Friend.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { memberIdSelector } from '../../../../redux/hooks';
 import { paletteCodeSelector } from '../../../../redux/hooks';
-import { getFriends, getSpecificPalette } from '../../../../api/FriendDataApi';
+import { getFriends } from '../../../../api/FriendDataApi';
 import { RightBottomLayout } from '../../../atoms/layout/Layouts';
 import Button from '../../../atoms/button/commonButton/Button';
 import Overlay from '../../../atoms/overlay/Overlay';
@@ -14,6 +14,7 @@ import 'react-toastify/dist/ReactToastify.css';
 import * as Style from './Style';
 import { useQuery } from '@tanstack/react-query';
 import { Friend } from '../../../module/friend/FriendType';
+import { getSpecificPalette } from '../../../../api/PaletteApi';
 
 const Friends = () => {
   const [isOpen, setIsOpen] = useState(false);

--- a/client/src/types/MoodType.ts
+++ b/client/src/types/MoodType.ts
@@ -1,0 +1,26 @@
+export interface MoodObj {
+  paletteCode: string;
+  moodCode: string;
+  colorCode: string;
+  mood: MoodType;
+  paletteKorName?: string;
+}
+
+type happy = '기쁨';
+type sad = '슬픔';
+type anger = '분노';
+type flutter = '설렘';
+type worry = '걱정';
+type calm = '평온';
+type sensitive = '예민';
+type hope = '희망';
+
+export type MoodType =
+  | happy
+  | sad
+  | anger
+  | flutter
+  | worry
+  | calm
+  | sensitive
+  | hope;


### PR DESCRIPTION
### Changes 📝
#208 
* 기존 코드:기존의 방식에서는 오늘의 무드 컬러를 가져올때, 유저의 팔레트를 가져온 후, 유저가 오늘의 기분을 지정했다면, find를 사용해 팔레트의 mood 프로퍼티와 유저 mood 프로퍼티가 같을 경우 리턴하는 형식을 취했음.
문제: 팔레트의 mood는 영어로 되어있는데 유저 mood는 한글로 되어있어 값이 제대로 나오지 못함.
해결: 
```ts
  const dayMood = useQuery({
    queryKey: ['dayMood'],
    queryFn: async () => {
      const data = await getDayMood(userInfo?.displayName);
      return data;
    },
  });
```

<br>

### Test Checklist ☑️
- [ ] 기존에는 리덕스에서 userMood와 userPalette를 받아왔는데 리액트 쿼리를 사용하는 것으로 수정.
- [ ] 팔레트 관련 api 분리, 무드 관련 api 생성
