### PR TITLE
refactor: 모달 너비 조정

### DIFF
--- a/client/src/components/templates/modals/IsFullModal.tsx
+++ b/client/src/components/templates/modals/IsFullModal.tsx
@@ -17,7 +17,7 @@ const IsFullModal: React.FC<FullPageProp> = ({ isFull, children }) => {
           />
         </div>
       )}
-      <div>{children}</div>
+      <div style={children ? { width: '100%' } : null}>{children}</div>
     </ContentLayout>
   );
 };


### PR DESCRIPTION
### Changes 📝
#208 
모달 너비가 무너져서 조정함.
isfullmodal 액자 컴포넌트를 만들면서 에러가 생긴 듯 함.
ifFullModal 컴포넌트에서 모달이 차지하는 너비를 100%로 맞춰줌.
<br>

### Test Checklist ☑️
- [ ] isFullModal에서 모달 진영에 with 100을 줬더니 모달이 열리지 않은 상태에서도 자리차지를 하길래 children 여부에 따라 스타일링 하도록 함.
