### PR TITLE
hotfix: dayMood 쿼리키에 userInfo 추가

### DIFF
--- a/client/src/components/module/header/user/User.tsx
+++ b/client/src/components/module/header/user/User.tsx
@@ -13,17 +13,20 @@ const User = ({ onClick }) => {
   const accessToken = getCookie('accessToken');
   // userInfo
   const memberId = useSelector(memberIdSelector);
-  const { data, isLoading, isError } = useQuery(['userInfo', memberId], {
+  const {
+    data: userInfo,
+    isLoading,
+    isError,
+  } = useQuery(['userInfo', memberId], {
     queryFn: async () => {
       const data = await getUserInfo(memberId);
       return data;
     },
   });
 
-  const userInfo = data;
   // todayMood
   const dayMood = useQuery({
-    queryKey: ['dayMood'],
+    queryKey: ['dayMood', userInfo?.displayName],
     queryFn: async () => {
       const data = await getDayMood(userInfo?.displayName);
       return data;


### PR DESCRIPTION
### Changes 📝
#218 
새로고침하면 유저무드가 사라지는 에러 발생.
새로고침하면 컴포넌트가 다시 마운트되고, 캐시된 데이터가 초기화됨.
dayMood 쿼리는 (userInfo가 존재할 때에만 쿼리를 실행하도록 했기 때문에) userInfo가 undeined가 되어 실행되지 않는다.
[벨로그 정리](https://velog.io/@koyk0408/refactor-useQuery-%EC%82%AC%EC%9A%A9%ED%95%A0-%EB%95%8C-%EC%A3%BC%EC%9D%98%ED%95%A0-%EC%A0%90)
<br>
```ts
  const dayMood = useQuery({
    queryKey: ['dayMood', userInfo?.displayName],
    queryFn: async () => {
      const data = await getDayMood(userInfo?.displayName);
      return data;
    },
    enabled: !!userInfo,
  });
```
### Test Checklist ☑️
- [ ] enabled: !!userInfo userInfo값이 있어야 실행.
- [ ] queryKey: ['dayMood', userInfo?.displayName] userInfo 값이 변하면 실행.
